### PR TITLE
Fixed issue with long pauses (> 10s)

### DIFF
--- a/whisper_server.py
+++ b/whisper_server.py
@@ -71,11 +71,12 @@ async def audio_stream(websocket, path):
                     if current_time - last_silence_log_time >= 2:  # Check if 2 seconds have passed
                         logger.info("Silence detected")
                         last_silence_log_time = current_time  # Update the timestamp
+                    
                     if not silence_started:
-                        online.finish()
+                        o = online.finish()
                     online.init()
 
-                silence_started = True
+                    silence_started = True
             else:
                 if silence_started:
                     last_silence_log_time = 0

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -62,7 +62,6 @@ async def audio_stream(websocket, path):
             
             if rms < SILENCE_THRESHOLD:
 
-                silence_started = True
                 silence_candidate.append(audio)
                 silence_candidate_len = sum(len(x) for x in silence_candidate)
 
@@ -72,7 +71,11 @@ async def audio_stream(websocket, path):
                     if current_time - last_silence_log_time >= 2:  # Check if 2 seconds have passed
                         logger.info("Silence detected")
                         last_silence_log_time = current_time  # Update the timestamp
+                    if not silence_started:
+                        online.finish()
                     online.init()
+
+                silence_started = True
             else:
                 if silence_started:
                     last_silence_log_time = 0


### PR DESCRIPTION
There's an issue with really long pauses (>10s) with the [current code](https://github.com/marcinmatys/whisper_streaming/blob/6de2b43a94c8f63adcefc4981bf6590c9e697a55/whisper_server.py#L64). Since `rms` is calculated as the **square root mean** of the ongoing `silence_candidate_chunk`, after a long pause when the speech starts again, `rms` will still be under the `SILENCE_THRESHOLD` for a while until the new data brings the mean back up above the threshold. From my experience it would take around 1/10 the duration of the pause for the ASR to picks up again, which means the first sentence after a pause will lose some words at the beginning. 

Calculating `rms` per received audio might be a better way to approach this. Of course lowering the threshold would work, but the filtering would still depend on the size of `silence_candidate_chunk`

Let me know if you can reproduce the issue. These were the arguments that I used.
```python whisper_server.py --backend faster-whisper --language en --min-chunk-size 1 --silence-size 2 --model base.en --silence-threshold 0.01```